### PR TITLE
Fix/tests and error on website stats

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+UMAMI_API_KEY=
+UMAMI_API_CLIENT_ENDPOINT=https://api.umami.is/v1
+
+UMAMI_WEBSITE_ID=

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  testTimeout: 20000,
   verbose: true,
   /* testEnvironment: 'jsdom', */
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   verbose: true,
-  testEnvironment: 'jsdom',
+  /* testEnvironment: 'jsdom', */
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   moduleNameMapper: {
     '\\.(css|less|jpg|png|svg)$': '<rootDir>/test/mocks/emptyModule.js',

--- a/src/UmamiApiClient.ts
+++ b/src/UmamiApiClient.ts
@@ -49,7 +49,7 @@ export class UmamiApiClient {
 
     log(`GET ${dest}`);
 
-    return get(dest, undefined, this.getHeaders(headers));
+    return get(dest, undefined, { ...this.getHeaders(headers), ...{ 'Content-Type': undefined } });
   }
 
   post(url: string, params?: object, headers?: object) {

--- a/src/UmamiApiClient.ts
+++ b/src/UmamiApiClient.ts
@@ -181,8 +181,8 @@ export class UmamiApiClient {
       endAt: string;
       unit: string;
       timezone: string;
-      url: string;
-      eventName: string;
+      url?: string;
+      eventName?: string;
     },
   ): Promise<ApiResponse<Umami.WebsiteMetric[]>> {
     return this.get(`websites/${websiteId}/events`, params);
@@ -194,17 +194,17 @@ export class UmamiApiClient {
       type: string;
       startAt: number;
       endAt: number;
-      url: string;
-      referrer: string;
-      title: string;
-      query: string;
-      event: string;
-      os: string;
-      browser: string;
-      device: string;
-      country: string;
-      region: string;
-      city: string;
+      url?: string;
+      referrer?: string;
+      title?: string;
+      query?: string;
+      event?: string;
+      os?: string;
+      browser?: string;
+      device?: string;
+      country?: string;
+      region?: string;
+      city?: string;
     },
   ): Promise<ApiResponse<Umami.WebsiteMetric[]>> {
     return this.get(`websites/${websiteId}/metrics`, params);
@@ -237,16 +237,16 @@ export class UmamiApiClient {
       startAt: number;
       endAt: number;
       url: string;
-      referrer: string;
-      title: string;
-      query: string;
-      event: string;
-      os: string;
-      browser: string;
-      device: string;
-      country: string;
-      region: string;
-      city: string;
+      referrer?: string;
+      title?: string;
+      query?: string;
+      event?: string;
+      os?: string;
+      browser?: string;
+      device?: string;
+      country?: string;
+      region?: string;
+      city?: string;
     },
   ): Promise<ApiResponse<Umami.WebsiteStats>> {
     return this.get(`websites/${websiteId}/stats`, params);

--- a/test.js
+++ b/test.js
@@ -11,11 +11,50 @@ describe('Testing all get functions', () => {
 
   async function testGetWebsites() {
     const results = await apiClient.client.getWebsites();
+
     return results.ok;
   }
 
   test('Testing: getWebsites', () => {
     return expect(testGetWebsites()).resolves.toBeTruthy();
+  });
+
+  async function testGetMe() {
+    const results = await apiClient.client.getMe();
+    return results.ok;
+  }
+
+  test('Testing: getMe', () => {
+    return expect(testGetMe()).resolves.toBeTruthy();
+  });
+
+  async function testGetWebsiteMetrics() {
+    const results = await apiClient.client.getWebsiteMetrics(process.env.UMAMI_WEBSITE_ID, {
+      startAt: 1685566800000,
+      endAt: 1686916052440,
+      type: 'url',
+    });
+
+    return results.ok;
+  }
+
+  test('Testing: getWebsiteMetrics', () => {
+    return expect(testGetWebsiteMetrics()).resolves.toBeTruthy();
+  });
+
+  async function testGetWebsitePageviews() {
+    const results = await apiClient.client.getWebsitePageviews(process.env.UMAMI_WEBSITE_ID, {
+      startAt: 1685566800000,
+      endAt: 1686916052440,
+      url: '/',
+      timezone: 'America/Los_Angeles',
+    });
+
+    return results.ok;
+  }
+
+  test('Testing: getWebsitePageviews', () => {
+    return expect(testGetWebsitePageviews()).resolves.toBeTruthy();
   });
 
   async function testGetWebsitesStats() {

--- a/test.js
+++ b/test.js
@@ -1,15 +1,34 @@
+require('cross-fetch/polyfill');
 const apiClient = require('./dist/cjs/index');
 const dotenv = require('dotenv');
 dotenv.config();
 
-(async () => {
-  apiClient.client = apiClient.getClient();
+describe('Testing all get functions', () => {
+  beforeAll(() => {
+    apiClient.client = apiClient.getClient();
+    return;
+  });
 
-  try {
-    const x = await apiClient.client.getWebsites();
-
-    console.log(x);
-  } catch (e) {
-    console.log('ERROR', { statusCode: e.statusCode, message: e.message, e });
+  async function testGetWebsites() {
+    const results = await apiClient.client.getWebsites();
+    return results.ok;
   }
-})();
+
+  test('Testing: getWebsites', () => {
+    return expect(testGetWebsites()).resolves.toBeTruthy();
+  });
+
+  async function testGetWebsitesStats() {
+    const results = await apiClient.client.getWebsiteStats(process.env.UMAMI_WEBSITE_ID, {
+      startAt: 1685566800000,
+      endAt: 1686916052440,
+      url: '/',
+    });
+
+    return results.ok;
+  }
+
+  test('Testing: getWebsitesStats', () => {
+    return expect(testGetWebsitesStats()).resolves.toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes https://github.com/umami-software/api-client/issues/2

Dependant on https://github.com/umami-software/api-client/pull/4

In this PR I am:
- Adding new jest tests for more coverage of the `get` functions on the client
- Looking to fix the error 500 when using the client on `getWebsiteStats`