### PR TITLE
Fix getWebsitePageviews return type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -65,11 +65,11 @@ export interface WebsitePageviews {
   pageviews: {
     t: string;
     y: number;
-  };
+  }[];
   sessions: {
     t: string;
     y: number;
-  };
+  }[];
 }
 
 export interface WebsiteStats {

--- a/test.js
+++ b/test.js
@@ -51,6 +51,7 @@ describe('Testing all get functions', () => {
       endAt: END_AT,
       url: '/',
       timezone: 'America/Los_Angeles',
+      unit: 'day',
     });
 
     return results.ok;


### PR DESCRIPTION
Return type definition for `getWebsitePageviews` was wrong. Tests were failing b/c of missing required `unit` param.