### PR TITLE
fix(type): inconsistency in type for WebsitePageviews

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -63,11 +63,11 @@ export interface WebsiteEventMetric {
 
 export interface WebsitePageviews {
   pageviews: {
-    t: string;
+    x: string;
     y: number;
   }[];
   sessions: {
-    t: string;
+    x: string;
     y: number;
   }[];
 }


### PR DESCRIPTION
found this bug where the type says it uses the symbol `t` for timestamp, when in reality the api uses the symbol `x`.